### PR TITLE
Use lightweight container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:latest as builder
 WORKDIR /go/src/github.com/akokshar/storage
 COPY . .
-RUN go build -a -race -o app .
+RUN CGO_ENABLED=0 go build -o app .
 
-FROM fedora:latest
-WORKDIR /root
-COPY --from=builder /go/src/github.com/akokshar/storage/app .
-CMD ["./app"]
+FROM scratch
+COPY --from=builder /go/src/github.com/akokshar/storage/app /
+CMD ["/app"]


### PR DESCRIPTION
Use scratch instead of Fedora as it's way more lightweight and now
storage doesn't need any ffi with C.